### PR TITLE
docs: fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Install tszip and create a new package:
 
 ```bash
 # install tszip globally
-yarn global add tszip
+yarn global add @tszip/tszip
 
 # create a package
 tszip create $PACKAGE_NAME


### PR DESCRIPTION
`tszip` refer to https://github.com/briosheje/tszip.
I expect that it is `@tszip/tszip`